### PR TITLE
Support sharing MongoClient between multiple stores

### DIFF
--- a/common/mongo/src/main/scala/whisk/core/database/mongo/ReferenceCounted.scala
+++ b/common/mongo/src/main/scala/whisk/core/database/mongo/ReferenceCounted.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.database.mongo
+
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicBoolean
+
+case class ReferenceCounted[T <: AutoCloseable](private val inner: T) {
+  private val count = new AtomicInteger(0)
+
+  private def inc(): Unit = count.incrementAndGet()
+
+  private def dec(): Unit = {
+    val newCount = count.decrementAndGet()
+    if (newCount == 0) {
+      inner.close()
+      count.decrementAndGet()
+    }
+  }
+
+  def isClosed: Boolean = count.get() < 0
+
+  def getReference: CountedReference = {
+    require(count.get >= 0, "Reference is already closed")
+    new CountedReference
+  }
+
+  class CountedReference extends AutoCloseable {
+    private val closed = new AtomicBoolean()
+    inc()
+    override def close(): Unit = if (closed.compareAndSet(false, true)) dec()
+
+    def get: T = inner
+  }
+}

--- a/tests/src/test/scala/whisk/core/database/mongo/MongoDbQueryTests.scala
+++ b/tests/src/test/scala/whisk/core/database/mongo/MongoDbQueryTests.scala
@@ -232,7 +232,7 @@ class MongoDbQueryTests extends FlatSpec with ArtifactStoreHelper with MongoSupp
     result shouldBe 10
   }
 
-  it should "should count with skip" in {
+  it should "count with skip" in {
     implicit val tid = transid()
 
     val ns = aname()

--- a/tests/src/test/scala/whisk/core/database/mongo/ReferenceCountedTests.scala
+++ b/tests/src/test/scala/whisk/core/database/mongo/ReferenceCountedTests.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.database.mongo
+
+import org.scalatest.Matchers
+import org.scalatest.FlatSpec
+
+class ReferenceCountedTests extends FlatSpec with Matchers {
+
+  class CloseProbe extends AutoCloseable {
+    var closed: Boolean = _
+    var closedCount: Int = _
+    override def close() = {
+      closed = true
+      closedCount += 1
+    }
+  }
+
+  behavior of "ReferenceCounted"
+
+  it should "close only once" in {
+    val probe = new CloseProbe
+    val refCounted = ReferenceCounted(probe)
+
+    val ref1 = refCounted.getReference
+
+    ref1.get should be theSameInstanceAs probe
+    ref1.close()
+    ref1.close()
+
+    probe.closed shouldBe true
+    probe.closedCount shouldBe 1
+  }
+
+  it should "not close with one reference active" in {
+    val probe = new CloseProbe
+    val refCounted = ReferenceCounted(probe)
+
+    val ref1 = refCounted.getReference
+    val ref2 = refCounted.getReference
+
+    ref1.close()
+    ref1.close()
+
+    probe.closed shouldBe false
+  }
+
+  it should "be closed when all reference close" in {
+    val probe = new CloseProbe
+    val refCounted = ReferenceCounted(probe)
+
+    val ref1 = refCounted.getReference
+    val ref2 = refCounted.getReference
+
+    ref1.close()
+    ref2.close()
+
+    probe.closed shouldBe true
+    probe.closedCount shouldBe 1
+  }
+
+  it should "throw exception if closed" in {
+    val probe = new CloseProbe
+    val refCounted = ReferenceCounted(probe)
+
+    val ref1 = refCounted.getReference
+    ref1.close()
+
+    intercept[IllegalArgumentException] {
+      refCounted.getReference
+    }
+  }
+}


### PR DESCRIPTION
Enables sharing of MongoClient between various ArtifactStore instances by using reference counting approach