### PR TITLE
Attachment support based on MongoDB GridFS

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,79 @@
+
+1. Review usage of dates in entity
+2. ArtifactStore#shutdown is not called in production code
+
+Subjects
+--------
+
+- Index on subject
+- Index on namespace.name
+- Index on uuid, key, !blocked
+- Index on namespace.uuid and namespace.key
+
+Projections
+-----------
+
+Whisks
+======
+- Index on type, namespace, updated
+- Index on type, rootns, updated
+- Index on root, updated - if type = packages, actions, triggers, rules
+
+Projections
+-----------
+
+action          - namespace, name, version, publish, annotations, updated, limits, doc.exec.binary, 
+packages        - namespace, name, version, publish, annotations, updated, binding
+packages-public - namespace, name, version, publish, annotations, updated, binding = false
+rules           - _id
+triggers        - namespace, name, version, publish, annotations, updated
+
+Entity Queries
+--------------
+WhiskEntityQueries#listAllInNamespace
+  val startKey = List(namespace.asString)
+  val endKey = List(namespace.asString, TOP)
+  reduce= false
+  descending = true
+  
+
+WhiskEntityQueries#listCollectionInNamespace
+  -  val startKey = List(path.asString, since map { _.toEpochMilli } getOrElse 0)
+     val endKey = List(path.asString, upto map { _.toEpochMilli } getOrElse TOP, TOP)
+  - reduce = false
+WhiskActivation#listActivationsMatchingName
+  - val startKey = List(namespace.addPath(path).asString, since map { _.toEpochMilli } getOrElse 0)
+    val endKey = List(namespace.addPath(path).asString, upto map { _.toEpochMilli } getOrElse TOP, TOP)
+  - reduce = false
+  - whisks-filters.v2.1.0-activations.js
+  WhiskEntityQueries#queries
+    - descending = true
+
+
+Activations
+===========
+
+Created in SequenceActions
+
+- Index on namespace, start
+- Index on start -> Used for cleanup (byDate) activationId != null
+- byDateWithLogs - TODO - Non sequence activations
+- Index on namespace/path(), start
+
+Projections
+-----------
+
+activations - namespace, name, version, publish, annotations, activationId, start, end, cause, response.statusCode
+
+
+
+Query
+-----
+
+- startKey = endKey -> Do by equals
+- if includeDocs = true then just transform
+
+To investigate
+--------------
+
+PrimitiveActions.invokeSingleAction - Says params are merged with action params superceding passed param

--- a/common/mongo/src/main/scala/whisk/core/database/mongo/AttachmentStore.scala
+++ b/common/mongo/src/main/scala/whisk/core/database/mongo/AttachmentStore.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.database.mongo
+
+import akka.http.scaladsl.model.ContentType
+import akka.stream.scaladsl.Source
+import akka.stream.scaladsl.Sink
+import akka.util.ByteString
+import whisk.common.TransactionId
+import whisk.core.entity.DocInfo
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
+
+trait AttachmentStore {
+
+  /** Execution context for futures */
+  protected[core] implicit val executionContext: ExecutionContext
+
+  /**
+   * Attaches a "file" of type `contentType` to an existing document. The revision for the document must be set.
+   */
+  protected[core] def attach(doc: DocInfo, name: String, contentType: ContentType, docStream: Source[ByteString, _])(
+    implicit transid: TransactionId): Future[DocInfo]
+
+  /**
+   * Retrieves a saved attachment, streaming it into the provided Sink.
+   */
+  protected[core] def readAttachment[T](doc: DocInfo, name: String, sink: Sink[ByteString, Future[T]])(
+    implicit transid: TransactionId): Future[(ContentType, T)]
+}

--- a/common/mongo/src/main/scala/whisk/core/database/mongo/MongoDbStore.scala
+++ b/common/mongo/src/main/scala/whisk/core/database/mongo/MongoDbStore.scala
@@ -75,6 +75,7 @@ class MongoDbStore[DocumentAbstraction <: DocumentSerializer](clientRef: Referen
                                                               collName: String,
                                                               documentHandler: DocumentHandler,
                                                               viewMapper: MongoViewMapper,
+                                                              attachmentStore: AttachmentStore,
                                                               useBatching: Boolean = false)(
   implicit system: ActorSystem,
   val logging: Logging,
@@ -87,8 +88,7 @@ class MongoDbStore[DocumentAbstraction <: DocumentSerializer](clientRef: Referen
 
   override protected[core] implicit val executionContext: ExecutionContext = system.dispatcher
 
-  private def client: MongoClient = clientRef.get
-  private val coll: MongoCollection[Document] = client.getDatabase(config.db).getCollection[Document](collName)
+  private val coll: MongoCollection[Document] = clientRef.get.getDatabase(config.db).getCollection[Document](collName)
 
   //TODO Index creation
   private val _id = "_id"
@@ -335,12 +335,12 @@ class MongoDbStore[DocumentAbstraction <: DocumentSerializer](clientRef: Referen
     name: String,
     contentType: ContentType,
     docStream: Source[ByteString, _])(implicit transid: TransactionId): Future[DocInfo] = {
-    Future.failed(new Exception()) //FIXME
+    attachmentStore.attach(doc, name, contentType, docStream)
   }
 
   override protected[core] def readAttachment[T](doc: DocInfo, name: String, sink: Sink[ByteString, Future[T]])(
     implicit transid: TransactionId): Future[(ContentType, T)] = {
-    Future.failed(new Exception()) //FIXME
+    attachmentStore.readAttachment(doc, name, sink)
   }
 
   override def shutdown(): Unit = {

--- a/common/mongo/src/main/scala/whisk/core/database/mongo/attachment/AsyncStreamSink.scala
+++ b/common/mongo/src/main/scala/whisk/core/database/mongo/attachment/AsyncStreamSink.scala
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.database.mongo.attachment
+
+import java.nio.ByteBuffer
+
+import akka.Done
+import akka.stream.IOResult
+import akka.stream.SinkShape
+import akka.stream.Inlet
+import akka.stream.Attributes
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Flow
+import akka.stream.stage.GraphStageWithMaterializedValue
+import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.InHandler
+import akka.stream.stage.AsyncCallback
+import akka.util.ByteString
+import org.mongodb.scala.Completed
+import org.mongodb.scala.gridfs.AsyncOutputStream
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Promise
+import scala.util.Try
+import scala.util.Success
+import scala.util.Failure
+
+class AsyncStreamSink(stream: AsyncOutputStream)(implicit ec: ExecutionContext)
+    extends GraphStageWithMaterializedValue[SinkShape[ByteString], Future[IOResult]] {
+  val in: Inlet[ByteString] = Inlet("AsyncStream.in")
+
+  override val shape: SinkShape[ByteString] = SinkShape(in)
+
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[IOResult]) = {
+    val ioResultPromise = Promise[IOResult]()
+    val logic = new GraphStageLogic(shape) with InHandler {
+      handler =>
+      var buffers: Iterator[ByteBuffer] = Iterator()
+      var writeCallback: AsyncCallback[Try[Int]] = _
+      var position: Int = _
+
+      setHandler(in, this)
+
+      override def preStart(): Unit = {
+        setKeepGoing(true)
+        writeCallback = getAsyncCallback[Try[Int]](handleWriteResult)
+        pull(in)
+      }
+
+      override def onPush(): Unit = {
+        buffers = grab(in).asByteBuffers.iterator
+        writeNextBufferOrPull()
+      }
+
+      override def onUpstreamFinish(): Unit = {
+        //Work done perform close
+        //callback does not work at this stage so register the close call directly
+        //as at this stage further no other interaction would happen with the sink
+        //stream.close().head().onComplete(closeCallback.invoke)
+        stream.close().head().onComplete(handleClose)
+      }
+
+      override def onUpstreamFailure(ex: Throwable): Unit = {
+        fail(ex)
+      }
+
+      private def handleWriteResult(bytesWrittenOrFailure: Try[Int]): Unit = bytesWrittenOrFailure match {
+        case Success(bytesWritten) =>
+          position += bytesWritten
+          writeNextBufferOrPull()
+        case Failure(failure) => fail(failure)
+      }
+
+      private def handleClose(completed: Try[Completed]): Unit = completed match {
+        case Success(Completed()) =>
+          completeStage()
+          ioResultPromise.trySuccess(IOResult(position, Success(Done)))
+        case Failure(failure) =>
+          fail(failure)
+      }
+
+      private def writeNextBufferOrPull(): Unit = {
+        if (buffers.hasNext) {
+          stream.write(buffers.next()).head().onComplete(writeCallback.invoke)
+        } else {
+          pull(in)
+        }
+      }
+
+      private def fail(failure: Throwable) = {
+        failStage(failure)
+        ioResultPromise.trySuccess(IOResult(position, Failure(failure)))
+      }
+
+    }
+    (logic, ioResultPromise.future)
+  }
+}
+
+object AsyncStreamSink {
+  def apply(stream: AsyncOutputStream)(implicit ec: ExecutionContext): Sink[ByteString, Future[IOResult]] = {
+    Sink.fromGraph(new AsyncStreamSink(stream))
+  }
+}

--- a/common/mongo/src/main/scala/whisk/core/database/mongo/attachment/AsyncStreamSource.scala
+++ b/common/mongo/src/main/scala/whisk/core/database/mongo/attachment/AsyncStreamSource.scala
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.database.mongo.attachment
+
+import java.nio.ByteBuffer
+
+import akka.Done
+import akka.stream.SourceShape
+import akka.stream.Attributes
+import akka.stream.Outlet
+import akka.stream.IOResult
+import akka.stream.scaladsl.Source
+import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.OutHandler
+import akka.stream.stage.GraphStageWithMaterializedValue
+import akka.stream.stage.AsyncCallback
+import akka.util.ByteString
+import org.mongodb.scala.Completed
+import org.mongodb.scala.gridfs.AsyncInputStream
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.util.Success
+import scala.util.Try
+import scala.util.Failure
+
+class AsyncStreamSource(stream: AsyncInputStream, chunkSize: Int)(implicit ec: ExecutionContext)
+    extends GraphStageWithMaterializedValue[SourceShape[ByteString], Future[IOResult]] {
+  require(chunkSize > 0, "chunkSize must be greater than 0")
+  val out: Outlet[ByteString] = Outlet("AsyncStream.out")
+
+  override val shape: SourceShape[ByteString] = SourceShape(out)
+
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[IOResult]) = {
+    val ioResultPromise = Promise[IOResult]()
+    val logic = new GraphStageLogic(shape) with OutHandler {
+      handler =>
+      val buffer = ByteBuffer.allocate(chunkSize)
+      var readCallback: AsyncCallback[Try[Int]] = _
+      var closeCallback: AsyncCallback[Try[Completed]] = _
+      var position: Int = _
+
+      setHandler(out, this)
+
+      override def preStart(): Unit = {
+        readCallback = getAsyncCallback[Try[Int]](handleBufferRead)
+        closeCallback = getAsyncCallback[Try[Completed]](handleClose)
+      }
+
+      override def onPull(): Unit = {
+        stream.read(buffer).head().onComplete(readCallback.invoke)
+      }
+
+      private def handleBufferRead(bytesReadOrFailure: Try[Int]): Unit = bytesReadOrFailure match {
+        case Success(bytesRead) if bytesRead >= 0 =>
+          buffer.flip
+          push(out, ByteString.fromByteBuffer(buffer))
+          buffer.clear
+          position += bytesRead
+        case Success(_) =>
+          stream.close().head().onComplete(closeCallback.invoke) //Work done perform close
+        case Failure(failure) =>
+          fail(failure)
+      }
+
+      private def handleClose(completed: Try[Completed]): Unit = completed match {
+        case Success(Completed()) =>
+          completeStage()
+          ioResultPromise.trySuccess(IOResult(position, Success(Done)))
+        case Failure(failure) =>
+          fail(failure)
+      }
+
+      private def fail(failure: Throwable) = {
+        failStage(failure)
+        ioResultPromise.trySuccess(IOResult(position, Failure(failure)))
+      }
+    }
+    (logic, ioResultPromise.future)
+  }
+}
+
+object AsyncStreamSource {
+  def apply(stream: AsyncInputStream, chunkSize: Int = 512 * 1024)(
+    implicit ec: ExecutionContext): Source[ByteString, Future[IOResult]] = {
+    Source.fromGraph(new AsyncStreamSource(stream, chunkSize))
+  }
+}

--- a/common/mongo/src/main/scala/whisk/core/database/mongo/attachment/GridFSAttachmentStore.scala
+++ b/common/mongo/src/main/scala/whisk/core/database/mongo/attachment/GridFSAttachmentStore.scala
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.database.mongo.attachment
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.ContentType
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import akka.event.Logging.ErrorLevel
+import akka.http.scaladsl.model.ContentTypes
+import akka.stream.ActorMaterializer
+import akka.util.ByteString
+import com.mongodb.client.gridfs.model.GridFSUploadOptions
+import org.mongodb.scala.MongoDatabase
+import org.mongodb.scala.gridfs.GridFSBucket
+import org.mongodb.scala._
+import org.mongodb.scala.bson.ObjectId
+import org.mongodb.scala.gridfs.GridFSFile
+import org.mongodb.scala.gridfs.MongoGridFSException
+import org.mongodb.scala.model.Filters
+import whisk.common.TransactionId
+import whisk.common.LoggingMarkers
+import whisk.common.Logging
+import whisk.core.database.ArtifactStoreException
+import whisk.core.database.NoDocumentException
+import whisk.core.database.mongo.AttachmentStore
+import whisk.core.entity.DocInfo
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
+
+class GridFSAttachmentStore(db: MongoDatabase, namespace: String)(implicit system: ActorSystem,
+                                                                  logging: Logging,
+                                                                  materializer: ActorMaterializer)
+    extends AttachmentStore {
+
+  override protected[core] implicit val executionContext: ExecutionContext = system.dispatcher
+
+  private val gridFS: GridFSBucket = GridFSBucket(db)
+
+  override protected[core] def attach(
+    doc: DocInfo,
+    name: String,
+    contentType: ContentType,
+    docStreamSource: Source[ByteString, _])(implicit transid: TransactionId): Future[DocInfo] = {
+    val start = transid.started(
+      this,
+      LoggingMarkers.DATABASE_ATT_SAVE,
+      s"[ATT_PUT] '$namespace' uploading attachment '$name' of document '$doc'")
+
+    require(doc != null, "doc undefined")
+    require(doc.rev.rev != null, "doc revision must be specified")
+
+    val filename = s"$namespace/${doc.id.id}/$name"
+    val renamedFile = s"$filename-new"
+    val options = new GridFSUploadOptions().metadata(Document("contentType" -> contentType.toString()))
+
+    def findExisting = gridFS.find(Filters.equal("filename", filename)).head()
+
+    def renameNew(existingFile: GridFSFile, newFileId: ObjectId) =
+      if (existingFile != null) gridFS.rename(newFileId, filename).head() else Future.successful(Completed())
+
+    def createNew(useTempNewName: Boolean) = {
+      val name = if (useTempNewName) renamedFile else filename
+      val uploadStream = gridFS.openUploadStream(name, options)
+      val sink = AsyncStreamSink(uploadStream)
+      docStreamSource.runWith(sink).map(_ => uploadStream.objectId)
+    }
+
+    def deleteOld(existingFile: GridFSFile) = {
+      if (existingFile == null) {
+        Future.successful(Completed())
+      } else {
+        gridFS.delete(existingFile.getId).head()
+      }
+    }
+
+    //Adding an attachment involves
+    //1. Find existing file
+    //2. if fileExists
+    //       2.1 create new file with a different name
+    //       2.2 delete old file
+    //       2.3 rename new file to expected name
+    //   else
+    //       create new file with required name
+
+    // @formatter:off
+    val f = for {
+      existingFile <- findExisting
+      newFileId    <- createNew(existingFile != null)
+      _            <- deleteOld(existingFile)
+      _            <- renameNew(existingFile, newFileId)
+    } yield doc
+    // @formatter:on
+
+    f.onSuccess {
+      case _ =>
+        transid
+          .finished(this, start, s"[ATT_PUT] '$namespace' completed uploading attachment '$name' of document '$doc'")
+    }
+
+    reportFailure(
+      f,
+      failure =>
+        transid.failed(
+          this,
+          start,
+          s"[ATT_PUT] '$namespace' internal error, name: '$name', doc: '$doc', failure: '${failure.getMessage}'",
+          ErrorLevel))
+  }
+
+  override protected[core] def readAttachment[T](doc: DocInfo, name: String, sink: Sink[ByteString, Future[T]])(
+    implicit transid: TransactionId): Future[(ContentType, T)] = {
+    val start = transid.started(
+      this,
+      LoggingMarkers.DATABASE_ATT_GET,
+      s"[ATT_GET] '$namespace' finding attachment '$name' of document '$doc'")
+
+    require(doc != null, "doc undefined")
+    require(doc.rev.rev != null, "doc revision must be specified")
+
+    val filename = s"$namespace/${doc.id.id}/$name"
+    val downloadStream = gridFS.openDownloadStream(filename)
+
+    def readStream(file: GridFSFile) = {
+      val source = AsyncStreamSource(downloadStream)
+      source.runWith(sink)
+    }
+
+    def getGridFSFile = {
+      downloadStream
+        .gridFSFile()
+        .head()
+        .transform(
+          identity, {
+            case ex: MongoGridFSException if ex.getMessage.contains("File not found") =>
+              transid.finished(
+                this,
+                start,
+                s"[ATT_GET] '$namespace', retrieving attachment '$name' of document '$doc'; not found.")
+              NoDocumentException("Not found on 'readAttachment'.")
+            case t => t
+          })
+    }
+
+    val f = for {
+      file <- getGridFSFile
+      result <- readStream(file)
+    } yield (getContentType(file), result)
+
+    reportFailure(
+      f,
+      failure =>
+        transid.failed(
+          this,
+          start,
+          s"[ATT_GET] '$namespace' internal error, name: '$name', doc: '$doc', failure: '${failure.getMessage}'",
+          ErrorLevel))
+  }
+
+  private def getContentType(file: GridFSFile): ContentType = {
+    val typeString = file.getMetadata.getString("contentType")
+    require(typeString != null, "Did not find 'contentType' in file metadata")
+    ContentType.parse(typeString) match {
+      case Right(ct) => ct
+      case Left(_)   => ContentTypes.`text/plain(UTF-8)` //Should not happen
+    }
+  }
+
+  private def reportFailure[T, U](f: Future[T], onFailure: Throwable => U): Future[T] = {
+    f.onFailure({
+      case _: ArtifactStoreException => // These failures are intentional and shouldn't trigger the catcher.
+      case x                         => onFailure(x)
+    })
+    f
+  }
+}

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -12,6 +12,7 @@ repositories {
 dependencies {
     compile "org.apache.openwhisk:openwhisk-tests:${gradle.openwhisk.version}:tests"
     compile "org.apache.openwhisk:openwhisk-tests:${gradle.openwhisk.version}:test-sources"
+    testCompile "org.mockito:mockito-core:2.15.0"
     compile project(':common:mongo')
     scoverage gradle.scoverage.deps
 }

--- a/tests/src/test/scala/whisk/core/database/mongo/AttachmentTests.scala
+++ b/tests/src/test/scala/whisk/core/database/mongo/AttachmentTests.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.database.mongo
+
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.concurrent.IntegrationPatience
+import org.scalatest.junit.JUnitRunner
+import whisk.core.controller.test.WhiskAuthHelpers
+import whisk.core.database.CacheChangeNotification
+import whisk.core.entity.Parameters
+import whisk.core.entity.WhiskAction
+import whisk.core.entity.EntityPath
+import whisk.core.entity.test.ExecHelpers
+
+@RunWith(classOf[JUnitRunner])
+class AttachmentTests
+    extends FlatSpec
+    with ArtifactStoreHelper
+    with MongoSupport
+    with ExecHelpers
+    with ScalaFutures
+    with IntegrationPatience {
+
+  behavior of "Attachments"
+
+  val creds = WhiskAuthHelpers.newIdentity()
+  val namespace = EntityPath(creds.subject.asString)
+  implicit val cacheUpdateNotifier: Option[CacheChangeNotification] = None
+
+  it should "get and put entity with attachment" in {
+    implicit val tid = transid()
+    val javaAction =
+      WhiskAction(
+        namespace,
+        MakeName.next("attachment"),
+        javaDefault("ZHViZWU=", Some("hello")),
+        annotations = Parameters("exec", "java"))
+
+    val pf = WhiskAction.put(entityStore, javaAction)
+    val docInfo = pf.futureValue
+
+    val gf = WhiskAction.get(entityStore, docInfo.id, docInfo.rev)
+    val readAction = gf.futureValue
+
+    readAction.exec shouldBe javaAction.exec
+  }
+
+}

--- a/tests/src/test/scala/whisk/core/database/mongo/OpenWhiskTests.scala
+++ b/tests/src/test/scala/whisk/core/database/mongo/OpenWhiskTests.scala
@@ -20,8 +20,9 @@ package whisk.core.database.mongo
 import org.junit.runner.RunWith
 import org.scalatest.Suites
 import org.scalatest.junit.JUnitRunner
+import whisk.core.controller.test.ActionsApiTests
 import whisk.core.entity.test.DatastoreTests
 import whisk.core.entity.test.ViewTests
 
 @RunWith(classOf[JUnitRunner])
-class OpenWhiskTests extends Suites(new DatastoreTests, new ViewTests)
+class OpenWhiskTests extends Suites(new DatastoreTests, new ViewTests, new ActionsApiTests)

--- a/tests/src/test/scala/whisk/core/database/mongo/attachment/AsyncStreamGraphTests.scala
+++ b/tests/src/test/scala/whisk/core/database/mongo/attachment/AsyncStreamGraphTests.scala
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.database.mongo.attachment
+
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.io.IOException
+import java.io.ByteArrayOutputStream
+
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.StreamConverters
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Keep
+import akka.stream.testkit.TestSubscriber
+import akka.util.ByteString
+import common.WskActorSystem
+import org.apache.commons.io.IOUtils
+import org.mongodb.scala.gridfs.helpers.AsyncStreamHelper
+import org.scalatest.Matchers
+import org.scalatest.FlatSpec
+import org.scalatest.concurrent.ScalaFutures
+import org.mockito.Mockito._
+import org.mockito.ArgumentMatchers._
+import org.scalatest.concurrent.IntegrationPatience
+import org.scalatest.mockito.MockitoSugar
+
+import scala.util.Random
+
+class AsyncStreamGraphTests
+    extends FlatSpec
+    with Matchers
+    with ScalaFutures
+    with WskActorSystem
+    with MockitoSugar
+    with IntegrationPatience {
+
+  implicit val mat = ActorMaterializer()
+
+  behavior of "AsyncStreamSource"
+
+  it should "read all bytes" in {
+    val bytes = randomBytes(4000)
+    val asyncStream = AsyncStreamHelper.toAsyncInputStream(bytes)
+
+    val readStream = AsyncStreamSource(asyncStream, 42).runWith(StreamConverters.asInputStream())
+    val readBytes = IOUtils.toByteArray(readStream)
+
+    bytes shouldBe readBytes
+  }
+
+  it should "close the stream when done" in {
+    val bytes = randomBytes(4000)
+    val inputStream = new ByteArrayInputStream(bytes)
+    val spiedStream = spy(inputStream)
+    val asyncStream = AsyncStreamHelper.toAsyncInputStream(spiedStream)
+
+    val readStream = AsyncStreamSource(asyncStream, 42).runWith(StreamConverters.asInputStream())
+    val readBytes = IOUtils.toByteArray(readStream)
+
+    bytes shouldBe readBytes
+    verify(spiedStream).close()
+  }
+
+  it should "onError with failure and return a failed IOResult when reading from failed stream" in {
+    val inputStream = mock[InputStream]
+
+    val exception = new IOException("Boom")
+    doThrow(exception).when(inputStream).read(any())
+    val asyncStream = AsyncStreamHelper.toAsyncInputStream(inputStream)
+
+    val (ioResult, p) = AsyncStreamSource(asyncStream).toMat(Sink.asPublisher(false))(Keep.both).run()
+    val c = TestSubscriber.manualProbe[ByteString]()
+    p.subscribe(c)
+
+    val sub = c.expectSubscription()
+    sub.request(1)
+
+    val error = c.expectError()
+    error.getCause should be theSameInstanceAs exception
+
+    ioResult.futureValue.status.isFailure shouldBe true
+  }
+
+  behavior of "AsyncStreamSink"
+
+  it should "write all bytes" in {
+    val bytes = randomBytes(4000)
+    val source = StreamConverters.fromInputStream(() => new ByteArrayInputStream(bytes), 42)
+
+    val os = new ByteArrayOutputStream()
+    val asyncStream = AsyncStreamHelper.toAsyncOutputStream(os)
+
+    val sink = AsyncStreamSink(asyncStream)
+    val ioResult = source.toMat(sink)(Keep.right).run()
+
+    ioResult.futureValue.count shouldBe bytes.length
+
+    val writtenBytes = os.toByteArray
+    writtenBytes shouldBe bytes
+  }
+
+  it should "close the stream when done" in {
+    val bytes = randomBytes(4000)
+    val source = StreamConverters.fromInputStream(() => new ByteArrayInputStream(bytes), 42)
+
+    val outputStream = new CloseRecordingStream()
+    val asyncStream = AsyncStreamHelper.toAsyncOutputStream(outputStream)
+
+    val sink = AsyncStreamSink(asyncStream)
+    val ioResult = source.toMat(sink)(Keep.right).run()
+
+    ioResult.futureValue.count shouldBe 4000
+    outputStream.toByteArray shouldBe bytes
+    outputStream.closed shouldBe true
+  }
+
+  it should "onError with failure and return a failed IOResult when writing to failed stream" in pending
+
+  private def randomBytes(size: Int): Array[Byte] = {
+    val arr = new Array[Byte](size)
+    Random.nextBytes(arr)
+    arr
+  }
+
+  private class CloseRecordingStream extends ByteArrayOutputStream {
+    var closed: Boolean = _
+    override def close() = { super.close(); closed = true }
+  }
+}

--- a/tests/src/test/scala/whisk/core/database/mongo/attachment/AsyncStreamGraphTests.scala
+++ b/tests/src/test/scala/whisk/core/database/mongo/attachment/AsyncStreamGraphTests.scala
@@ -31,6 +31,7 @@ import akka.stream.testkit.TestSubscriber
 import akka.util.ByteString
 import common.WskActorSystem
 import org.apache.commons.io.IOUtils
+import org.junit.runner.RunWith
 import org.mongodb.scala.gridfs.helpers.AsyncStreamHelper
 import org.scalatest.Matchers
 import org.scalatest.FlatSpec
@@ -38,10 +39,12 @@ import org.scalatest.concurrent.ScalaFutures
 import org.mockito.Mockito._
 import org.mockito.ArgumentMatchers._
 import org.scalatest.concurrent.IntegrationPatience
+import org.scalatest.junit.JUnitRunner
 import org.scalatest.mockito.MockitoSugar
 
 import scala.util.Random
 
+@RunWith(classOf[JUnitRunner])
 class AsyncStreamGraphTests
     extends FlatSpec
     with Matchers

--- a/tests/src/test/scala/whisk/core/database/mongo/attachment/GridFSAttachmentStoreTests.scala
+++ b/tests/src/test/scala/whisk/core/database/mongo/attachment/GridFSAttachmentStoreTests.scala
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.database.mongo.attachment
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+
+import akka.http.scaladsl.model.ContentTypes
+import akka.stream.scaladsl.StreamConverters
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.concurrent.IntegrationPatience
+import org.scalatest.junit.JUnitRunner
+import whisk.core.database.NoDocumentException
+import whisk.core.database.mongo.MongoSupport
+import whisk.core.database.mongo.ArtifactStoreHelper
+import whisk.core.entity.DocInfo
+
+import scala.util.Random
+
+@RunWith(classOf[JUnitRunner])
+class GridFSAttachmentStoreTests
+    extends FlatSpec
+    with ArtifactStoreHelper
+    with ScalaFutures
+    with IntegrationPatience
+    with MongoSupport {
+
+  debug = true
+
+  behavior of "Attachments"
+
+  it should "add some binary content" in {
+    implicit val tid = transid()
+    val store = createStore()
+    val bytes = randomBytes(4000)
+
+    val info = DocInfo ! (newActionName, "1")
+    val source = StreamConverters.fromInputStream(() => new ByteArrayInputStream(bytes), 42)
+    val result = store.attach(info, "code", ContentTypes.`application/octet-stream`, source)
+
+    result.futureValue shouldBe info
+  }
+
+  it should "add and read some binary content" in {
+    implicit val tid = transid()
+    val store = createStore()
+    val bytes = randomBytes(4000)
+
+    val info = DocInfo ! (newActionName, "1")
+    val source = StreamConverters.fromInputStream(() => new ByteArrayInputStream(bytes), 42)
+    val writeResult = store.attach(info, "code", ContentTypes.`application/octet-stream`, source)
+
+    writeResult.futureValue shouldBe info
+
+    val os = new ByteArrayOutputStream()
+    val sink = StreamConverters.fromOutputStream(() => os)
+    val readResultFuture = store.readAttachment(info, "code", sink)
+
+    val (readContentType, ioResult) = readResultFuture.futureValue
+
+    readContentType shouldBe ContentTypes.`application/octet-stream`
+    ioResult.count shouldBe bytes.length
+    os.toByteArray shouldBe bytes
+  }
+
+  it should "add and then update binary content" in {
+    implicit val tid = transid()
+    val store = createStore()
+    val bytes1 = randomBytes(4000)
+
+    val info = DocInfo ! (newActionName, "1")
+    val source = StreamConverters.fromInputStream(() => new ByteArrayInputStream(bytes1), 42)
+    val writeResult = store.attach(info, "code", ContentTypes.`application/octet-stream`, source)
+
+    writeResult.futureValue shouldBe info
+
+    val bytes2 = randomBytes(7000)
+    val source2 = StreamConverters.fromInputStream(() => new ByteArrayInputStream(bytes2), 42)
+    val writeResult2 = store.attach(info, "code", ContentTypes.`application/json`, source2)
+
+    writeResult2.futureValue shouldBe info
+
+    val os = new ByteArrayOutputStream()
+    val sink = StreamConverters.fromOutputStream(() => os)
+    val readResultFuture = store.readAttachment(info, "code", sink)
+
+    val (readContentType, ioResult) = readResultFuture.futureValue
+
+    readContentType shouldBe ContentTypes.`application/json`
+    ioResult.count shouldBe bytes2.length
+    os.toByteArray shouldBe bytes2
+  }
+
+  it should "throw NoDocumentException on reading non existing file" in {
+    implicit val tid = transid()
+    val store = createStore()
+
+    val os = new ByteArrayOutputStream()
+    val sink = StreamConverters.fromOutputStream(() => os)
+    val info = DocInfo ! ("nonExistingAction", "1")
+    val f = store.readAttachment(info, "code", sink)
+
+    f.failed.futureValue shouldBe a[NoDocumentException]
+  }
+
+  private def createStore() = {
+    new GridFSAttachmentStore(mongoClient.getDatabase(mongoConfig.db), "whisks")
+  }
+
+  private def randomBytes(size: Int): Array[Byte] = {
+    val arr = new Array[Byte](size)
+    Random.nextBytes(arr)
+    arr
+  }
+
+  private def newActionName = MakeName.next("gridFSTestAction").name
+}

--- a/tests/src/test/scala/whisk/core/database/mongo/attachment/GridFSAttachmentStoreTests.scala
+++ b/tests/src/test/scala/whisk/core/database/mongo/attachment/GridFSAttachmentStoreTests.scala
@@ -42,8 +42,6 @@ class GridFSAttachmentStoreTests
     with IntegrationPatience
     with MongoSupport {
 
-  debug = true
-
   behavior of "Attachments"
 
   it should "add some binary content" in {

--- a/whisk.properties
+++ b/whisk.properties
@@ -3,3 +3,22 @@ runtimes.manifest={"blackboxes": [{"name": "dockerskeleton"}], "runtimes": {"pyt
 db.whisk.auths=whisk_local_subjects
 db.whisk.actions=whisk_local_whisks
 db.whisk.activations=whisk_local_activations
+
+#Properties below were required for ActionsApiTests
+
+db.provider=CouchDB
+db.protocol=http
+db.username=whisk_admin
+db.password=some_passw0rd
+db.host=172.17.0.1
+db.port=5984
+
+whisk.version.date=2018-02-15T12:55:59Z
+whisk.version.buildno=latest
+
+limits.actions.invokes.perMinute=60
+limits.actions.invokes.concurrent=30
+limits.actions.invokes.concurrentInSystem=5000
+limits.triggers.fires.perMinute=60
+limits.actions.sequence.maxLength=50
+controller.instances=1


### PR DESCRIPTION
Implement support for storing attachments in MongoDB GridFS by implementing a Sink and Source for GridFS Async streams 