### PR TITLE
Fix transitive dependencies

### DIFF
--- a/common/mongo/build.gradle
+++ b/common/mongo/build.gradle
@@ -10,11 +10,13 @@ apply plugin: 'com.jfrog.bintray'
 project.archivesBaseName = "openwhisk-mongo"
 
 group 'org.github.chetanmeh'
-version '0.0.1'
+version '0.0.2'
 
 dependencies {
-    compile "org.apache.openwhisk:openwhisk-common:${gradle.openwhisk.version}"
-    compile "org.mongodb.scala:mongo-scala-driver_2.11:2.1.0"
+    compileOnly "org.apache.openwhisk:openwhisk-common:${gradle.openwhisk.version}"
+    compile ("org.mongodb.scala:mongo-scala-driver_2.11:2.1.0"){
+        exclude group:"org.scala-lang"
+    }
     scoverage gradle.scoverage.deps
 }
 

--- a/core/docker-common.gradle
+++ b/core/docker-common.gradle
@@ -20,10 +20,7 @@ configurations {
 }
 
 dependencies {
-    docker(project(':common:mongo')){
-        exclude group:"org.apache.openwhisk", module:"openwhisk-common"
-        exclude group:"org.scala-lang"
-    }
+    docker(project(':common:mongo'))
 }
 
 //By default the base image extend from official 'openwhisk' images


### PR DESCRIPTION
- Exclude Scala from Mongo driver
- Use [compileOnly][1] for dependency on OpenWhisk such that those dependencies are not included transitively

[1]: https://blog.gradle.org/introducing-compile-only-dependencies